### PR TITLE
macos needs brew include dir

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -70,7 +70,7 @@ configure_file(${CMAKE_SOURCE_DIR}/systemd/tinymush.service.in ${CMAKE_CURRENT_B
 include_directories(${CMAKE_SOURCE_DIR}/netmush)
 include_directories(${CMAKE_CURRENT_BINARY_DIR}/include)
 if(APPLE)
-    include_directories(/usr/local/include)
+    include_directories(/usr/local/include /opt/homebrew/include)
 endif(APPLE)
 
 macro(install_symlink filepath sympath)

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -47,3 +47,4 @@ The structure of TinyMUSH has changed again, here's the new directory tree and a
 ```
 
 More documentation will be available as development goes.
+

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -14,7 +14,7 @@ TinyMUSH now use the CMAKE build system, which is alot easier to maintain than A
 
     For OSX:
     ```
-    brew install cmake gdbm pcre`
+    brew install cmake gdbm pcre
     ```
 
 2. Build TinyMUSH:
@@ -28,7 +28,7 @@ TinyMUSH now use the CMAKE build system, which is alot easier to maintain than A
     ./netmush
     ```
 
-Default port is '6250' and default God's password is 'Potrzebie'.
+Default port is '6250' and default God's password is 'potrzebie'.
 
 ## Structure
 


### PR DESCRIPTION
As per the instructions to `brew install cmake gdbm pre`, the homebrew include dir has to be included in the cmake file.

Also, fix a couple of typos.