### PR TITLE
fix: eval.c: fix parsing of %= substitution parameter

### DIFF
--- a/scripts/eval_substitutions.conf
+++ b/scripts/eval_substitutions.conf
@@ -1,0 +1,19 @@
+# TinyMUSH Test for %-substitutions in string evaluations
+
+think %% %\ | % \
+
+@sex me=p
+think %n %s %o %p %a | Wizard they them their theirs
+
+think %! %@ %+ | #1 #1 0
+
+@va me=test_va
+&test me=test_attrib
+think %va | test_va
+think %=<test> | test_attrib
+
+think [setx(a, x_a)][setx(testx, x_testx)] %_a %_<testx> | x_a x_testx
+
+think [setq(a, q_a)][setq(testq, q_testq)] %qa %q<testq> | q_a q_testq
+
+

--- a/src/netmush/eval.c
+++ b/src/netmush/eval.c
@@ -1316,6 +1316,9 @@ void eval_expression_string(char *buff, char **bufc, dbref player, dbref caller,
 			break;
 
 		case '=':
+		        // Equivalent of generic v() attr get
+		        (*dstr)++;
+
 				if (**dstr != '<')
 				{
 					(*dstr)--;


### PR DESCRIPTION
In commit df879228bbfd2779a51458b9ba6cf77c302aa537, the statement advancing the string pointer while parsing the parameter for %= substitution was removed (presumably by accident), breaking %= substitutions entirely.

This PR adds the missing statement back, fixing %= substitution.

This PR also includes test cases to hopefully cover substitution issues in the future.