### PR TITLE
fix(boolexp.c): Always evaluate numerical attribute locks if the check is internal

### DIFF
--- a/src/netmush/boolexp.c
+++ b/src/netmush/boolexp.c
@@ -500,7 +500,7 @@ void skip_whitespace(char **pBuf)
  * @param parse_player	DBref of player triggering the test
  * @return BOOLEXP*		Boolean expression with the result of the test
  */
-BOOLEXP *test_atr(char *s, dbref parse_player)
+BOOLEXP *test_atr(char *s, dbref parse_player, bool parsing_internal)
 {
 	ATTR *attrib = NULL;
 	BOOLEXP *b = NULL;
@@ -542,7 +542,7 @@ BOOLEXP *test_atr(char *s, dbref parse_player)
 		 * Only #1 can lock on numbers
 		 *
 		 */
-		if (!God(parse_player))
+		if (!parsing_internal && !God(parse_player))
 		{
 			XFREE(buff);
 			return ((BOOLEXP *)NULL);
@@ -647,7 +647,7 @@ BOOLEXP *parse_boolexp_L(char **pBuf, dbref parse_player, bool parsing_internal)
 		 * check for an attribute
 		 *
 		 */
-		if ((b = test_atr(buf, parse_player)) != NULL)
+		if ((b = test_atr(buf, parse_player, parsing_internal)) != NULL)
 		{
 			XFREE(buf);
 			return (b);

--- a/src/netmush/prototypes.h
+++ b/src/netmush/prototypes.h
@@ -75,7 +75,7 @@ extern void free_boolexp(BOOLEXP *b);
 extern _Bool eval_boolexp(dbref player, dbref thing, dbref from, BOOLEXP *b);
 extern _Bool eval_boolexp_atr(dbref player, dbref thing, dbref from, char *key);
 extern void skip_whitespace(char **pBuf);
-extern BOOLEXP *test_atr(char *s, dbref parse_player);
+extern BOOLEXP *test_atr(char *s, dbref parse_player, _Bool parsing_internal);
 extern BOOLEXP *parse_boolexp_L(char **pBuf, dbref parse_player, _Bool parsing_internal);
 extern BOOLEXP *parse_boolexp_F(char **pBuf, dbref parse_player, _Bool parsing_internal);
 extern BOOLEXP *parse_boolexp_T(char **pBuf, dbref parse_player, _Bool parsing_internal);


### PR DESCRIPTION
By passing on the `parsing_internal` flag, we can distinguish in `test_atr()` whether we are parsing a lock from the DB or a lock input by the player. In the latter case, we check permissions as before, only allowing the God player to create numeric locks.

However, in the former case, this check is skipped. That way, if a database contains numerical attribute locks for whatever reason (e.g. because it has been migrated from TinyMUSH 3), the lock still works as expected for non-God players.

This fixes #27