### PR TITLE
fix(db_backend_gdbm.c): Add missing includes

### DIFF
--- a/src/netmush/db_backend_gdbm.c
+++ b/src/netmush/db_backend_gdbm.c
@@ -22,12 +22,15 @@
 #include <stdbool.h>
 #include <limits.h>
 #include <dlfcn.h>
+#include <errno.h>
 #include <getopt.h>
 #include <gdbm.h>
 #include <libgen.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
 #include <sys/file.h>
+#include <sys/stat.h>
 #include <unistd.h>
 
 /* GDBM-specific state */


### PR DESCRIPTION
Currently, TinyMUSH does not compile for me with GDBM backend configured due to missing includes. This PR adds the missing includes to `db_backend_gdbm.c`, allowing the software to compile again without errors or warnings.