### PR TITLE
Potential fix for code scanning alert no. 59: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/macos-latest.yml
+++ b/.github/workflows/macos-latest.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ master ]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: macos-latest


### PR DESCRIPTION
Potential fix for [https://github.com/TinyMUSH/TinyMUSH/security/code-scanning/59](https://github.com/TinyMUSH/TinyMUSH/security/code-scanning/59)

In general, to fix this issue you explicitly declare a `permissions` block either at the workflow root (applies to all jobs without their own permissions) or at the job level, giving the minimal set of permissions required. For a pure build-and-test workflow that only checks out code and runs local commands, `contents: read` is usually sufficient.

For this specific workflow, the simplest fix without changing functionality is to add a `permissions` block at the top level, right after the `on:` section (or before `jobs:`), setting `contents: read`. None of the steps need write access to the repository or to other GitHub resources, so restricting to read-only is safe. Concretely, in `.github/workflows/macos-latest.yml`, you will insert:

```yaml
permissions:
  contents: read
```

between the `on:` block (lines 3–7) and the `jobs:` block (line 9). No additional methods, imports, or definitions are needed; GitHub Actions understands the `permissions` key natively.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
