### PR TITLE
Potential fix for code scanning alert no. 60: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ubuntu-latest.yml
+++ b/.github/workflows/ubuntu-latest.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ master ]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/TinyMUSH/TinyMUSH/security/code-scanning/60](https://github.com/TinyMUSH/TinyMUSH/security/code-scanning/60)

To fix the problem, add an explicit `permissions` block that restricts the `GITHUB_TOKEN` to the least privileges needed. This workflow only checks out code and runs local build/tests, so `contents: read` is sufficient. The most straightforward fix is to add a top-level `permissions` block (sibling to `on` and `jobs`) so it applies to all jobs in this workflow.

Concretely, in `.github/workflows/ubuntu-latest.yml`, insert:

```yaml
permissions:
  contents: read
```

between the `on:` section (lines 3–7) and the `jobs:` section (line 9). No imports or additional methods are needed, since this is a YAML configuration change only. This will constrain `GITHUB_TOKEN` for the entire workflow without altering the behavior of the existing steps.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
