### PR TITLE
Potential fix for code scanning alert no. 61: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/Doxygen.yml
+++ b/.github/workflows/Doxygen.yml
@@ -21,6 +21,8 @@ on:
 jobs:
   # This workflow contains a single job called "build"
   Doxygen:
+    permissions:
+      contents: write
     # The type of runner that the job will run on
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
Potential fix for [https://github.com/TinyMUSH/TinyMUSH/security/code-scanning/61](https://github.com/TinyMUSH/TinyMUSH/security/code-scanning/61)

To fix the problem, add an explicit `permissions` block to the workflow so that the GITHUB_TOKEN is granted only the minimum rights required. Since this workflow publishes documentation to the `gh-pages` branch using `peaceiris/actions-gh-pages`, it needs write access to repository contents but does not appear to need any additional scopes like `issues` or `pull-requests`.

The best minimally invasive fix is to add a `permissions` section at the job level under `Doxygen:` so that only this job gets `contents: write`. This avoids changing other workflows and keeps functionality intact. Specifically, in `.github/workflows/Doxygen.yml`, between `Doxygen:` (line 23) and `runs-on: ubuntu-latest` (line 25), insert:

```yaml
    permissions:
      contents: write
```

No imports or additional definitions are needed; this is purely a configuration change in the workflow YAML.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
