### PR TITLE
Potential fix for code scanning alert no. 73: Too few arguments to formatting function

### DIFF
--- a/src/netmush/boolexp.c
+++ b/src/netmush/boolexp.c
@@ -286,7 +286,7 @@ bool eval_boolexp(dbref player, dbref thing, dbref from, BOOLEXP *b)
 			}
 			else
 			{
-				log_write(LOG_BUGS, "BUG", "LOCK", "%s in %s: Lock had bad indirection (%c, type %d)", pname, INDIR_TOKEN, b->sub1->type);
+				log_write(LOG_BUGS, "BUG", "LOCK", "%s: Lock had bad indirection (%c, type %d)", pname, INDIR_TOKEN, b->sub1->type);
 			}
 			XFREE(pname);
 


### PR DESCRIPTION
Potential fix for [https://github.com/TinyMUSH/TinyMUSH/security/code-scanning/73](https://github.com/TinyMUSH/TinyMUSH/security/code-scanning/73)

In general, to fix “too few arguments to formatting function” issues, ensure that the number and types of arguments passed after the format string match the format specifiers within the string and the expectations of the called function or macro. Here, `log_write` is used twice with what appears to be the same format string, but one call omits an argument.

Specifically, in `src/netmush/boolexp.c`, around the `BOOLEXP_INDIR` case, there are two logging branches for “Lock had bad indirection”. The first (lines 282–285) is used when `LOGOPT_LOC` is set and the player has a location; it logs with the format `"%s in %s: Lock had bad indirection (%c, type %d)"` and passes four arguments: `pname, lname, INDIR_TOKEN, b->sub1->type`. The `else` branch at line 288 uses the same format string but currently passes only three arguments: `pname, INDIR_TOKEN, b->sub1->type`. To fix the bug without changing behavior, we should change the format string in the `else` branch to match its available arguments. Since this branch is for when we *do not* have a location, the natural text is `"%s: Lock had bad indirection (%c, type %d)"`, i.e., drop the “in %s” and correspondingly drop the missing `lname` argument.

No new imports or helper functions are required. The fix is a one-line change to the `log_write` call in the `else` branch: update the format string so it has three specifiers (`%s`, `%c`, `%d`) matching the three arguments already provided.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
