### PR TITLE
Potential fix for code scanning alert no. 62: Redundant null check due to previous dereference

### DIFF
--- a/src/modules/mail/mail.c
+++ b/src/modules/mail/mail.c
@@ -2929,9 +2929,11 @@ static int sign(int x)
 
 void do_malias_switch(dbref player, char *a1, char *a2)
 {
-    if ((!a2 || !*a2) && !(!a1 || !*a1))
+    /* If second argument is missing/empty and first is present/non-empty, list that alias */
+    if ((!a2 || !*a2) && a1 && *a1)
         do_malias_list(player, a1);
-    else if ((!*a1 || !a1) && (!*a2 || !a2))
+    /* If both arguments are missing/empty, list all aliases */
+    else if ((!a1 || !*a1) && (!a2 || !*a2))
         do_malias_list_all(player);
     else
         do_malias_create(player, a1, a2);


### PR DESCRIPTION
Potential fix for [https://github.com/TinyMUSH/TinyMUSH/security/code-scanning/62](https://github.com/TinyMUSH/TinyMUSH/security/code-scanning/62)

In general, to fix this kind of issue you must ensure that any pointer is checked for `NULL` before it is dereferenced, or, if it is proven non‑NULL, remove the redundant null checks. Here, the best fix is to adjust the conditional expressions to test the pointer first and only dereference it if it is non‑NULL, while keeping the logical behavior the same.

Concretely, in `do_malias_switch`:

- The first `if` uses `(!a2 || !*a2)` correctly (checks `a2` before `*a2`), but the second `else if` uses `(!*a1 || !a1)` and `(!*a2 || !a2)`, which dereferences before checking for `NULL`.  
- We should rewrite these conditions so the pointer is checked for `NULL` first, and only then is dereferenced. We can also simplify the logic by using equivalences like “string is missing or empty” → `(ptr == NULL || *ptr == '\0')`.

Proposed detailed changes in `src/modules/mail/mail.c`:

- Line 2932–2937: rewrite the logic of `do_malias_switch` as:
  - First branch: if `a2` is NULL or empty and `a1` is non‑NULL and non‑empty, call `do_malias_list(player, a1)`.
  - Second branch: if both `a1` and `a2` are NULL or empty, call `do_malias_list_all(player)`.
  - Else: call `do_malias_create(player, a1, a2)`.

This can be expressed safely as:

```c
if ((!a2 || !*a2) && a1 && *a1)
    ...
else if ((!a1 || !*a1) && (!a2 || !*a2))
    ...
else
    ...
```

No new methods, imports, or definitions are needed; we only adjust the boolean expressions.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
