### PR TITLE
Potential fix for code scanning alert no. 64: Redundant null check due to previous dereference

### DIFF
--- a/src/modules/mail/mail.c
+++ b/src/modules/mail/mail.c
@@ -1513,7 +1513,7 @@ void do_mail_stats(dbref player, char *name, int full)
      * find player
      */
 
-    if ((*name == '\0') || !name)
+    if (!name || (*name == '\0'))
     {
         if Wizard (player)
             target = AMBIGUOUS;


### PR DESCRIPTION
Potential fix for [https://github.com/TinyMUSH/TinyMUSH/security/code-scanning/64](https://github.com/TinyMUSH/TinyMUSH/security/code-scanning/64)

In general, to fix a “redundant null check due to previous dereference” you either (1) move the null check before any dereference, or (2) if the pointer is guaranteed non-null, remove the null-check entirely. Here, the expression `(*name == '\0') || !name` dereferences `name` first, so if `name` could be NULL that is a real bug. We should avoid dereferencing `name` until after confirming it is non-null.

The safest minimal change that preserves existing behavior is to rewrite the condition so that `name` is checked for NULL before it is dereferenced, and to maintain short-circuiting. That can be done by checking `!name` first, then falling back to the `*name == '\0'` test only if `name` is not NULL. Since we cannot change callers, and we must not change observable logic, we should keep the semantics “if name is NULL or empty string, treat it as no name specified”. So on line 1516 in `src/modules/mail/mail.c`, change:

```c
if ((*name == '\0') || !name)
```

to:

```c
if (!name || (*name == '\0'))
```

This uses the same two conditions but reorders them so the null check is evaluated before dereferencing `*name`, relying on C’s left-to-right, short-circuit evaluation of `||`. No extra methods, imports, or definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
