### PR TITLE
Potential fix for code scanning alert no. 65: Redundant null check due to previous dereference

### DIFF
--- a/src/netmush/command.c
+++ b/src/netmush/command.c
@@ -1747,12 +1747,12 @@ void process_cmdline(dbref player, dbref cause, char *cmdline, char *args[], int
 
 					   notify_check(player, player, MSG_PUP_ALWAYS | MSG_ME_ALL | MSG_F_DOWN, NULL,
 										 "[DEBUG process_cmdline] RAW cp='%s' (len=%d)",
-										 cp ? cp : "<NULL>", cp ? (int)strlen(cp) : 0);
+										 cp, (int)strlen(cp));
 					   log_write(LOG_ALWAYS, "TRIG", "CMDLINE", "[DEBUG process_cmdline] RAW cp='%s' (len=%d) (player=#%d, cause=#%d)",
-								 cp ? cp : "<NULL>", cp ? (int)strlen(cp) : 0, player, cause);
+								 cp, (int)strlen(cp), player, cause);
 					   notify_check(player, player, MSG_PUP_ALWAYS | MSG_ME_ALL | MSG_F_DOWN, NULL,
 									 "[DEBUG process_cmdline] about to call process_command: '%s'",
-									 cp ? cp : "<NULL>");
+									 cp);
 				       numpipes = 0;
 				       while (cmdline && (*cmdline == '|') && (!qent || qent == mushstate.qfirst) && (numpipes < mushconf.ntfy_nest_lim))
 				       {


### PR DESCRIPTION
Potential fix for [https://github.com/TinyMUSH/TinyMUSH/security/code-scanning/65](https://github.com/TinyMUSH/TinyMUSH/security/code-scanning/65)

In general, to fix a “redundant null check due to previous dereference” you either (a) move the null check before the first dereference, or (b) if the code structure already guarantees non-nullness at that point, remove the redundant null check. Here, the `if (cp && *cp)` condition already asserts `cp` is non-null for the entire body, so the correct and minimal change is to remove the `cp ? ... : ...` ternary expressions in that block and use `cp` directly.

Concretely, within `src/netmush/command.c` around lines 1745–1755, update the three debug/logging calls to remove the `cp ? ... : "<NULL>"` and `cp ? (int)strlen(cp) : 0` constructs and just use `cp` and `(int)strlen(cp)` respectively. This does not change behavior because those calls execute only when `cp` is non-null and `*cp` is non-zero. No new imports, methods, or definitions are required; we are only simplifying expressions in existing calls.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
