### PR TITLE
Potential fix for code scanning alert no. 66: Redundant null check due to previous dereference

### DIFF
--- a/src/netmush/command.c
+++ b/src/netmush/command.c
@@ -1747,12 +1747,12 @@ void process_cmdline(dbref player, dbref cause, char *cmdline, char *args[], int
 
 					   notify_check(player, player, MSG_PUP_ALWAYS | MSG_ME_ALL | MSG_F_DOWN, NULL,
 										 "[DEBUG process_cmdline] RAW cp='%s' (len=%d)",
-										 cp ? cp : "<NULL>", cp ? (int)strlen(cp) : 0);
+										 cp, (int)strlen(cp));
 					   log_write(LOG_ALWAYS, "TRIG", "CMDLINE", "[DEBUG process_cmdline] RAW cp='%s' (len=%d) (player=#%d, cause=#%d)",
-								 cp ? cp : "<NULL>", cp ? (int)strlen(cp) : 0, player, cause);
+								 cp, (int)strlen(cp), player, cause);
 					   notify_check(player, player, MSG_PUP_ALWAYS | MSG_ME_ALL | MSG_F_DOWN, NULL,
 									 "[DEBUG process_cmdline] about to call process_command: '%s'",
-									 cp ? cp : "<NULL>");
+									 cp);
 				       numpipes = 0;
 				       while (cmdline && (*cmdline == '|') && (!qent || qent == mushstate.qfirst) && (numpipes < mushconf.ntfy_nest_lim))
 				       {


### PR DESCRIPTION
Potential fix for [https://github.com/TinyMUSH/TinyMUSH/security/code-scanning/66](https://github.com/TinyMUSH/TinyMUSH/security/code-scanning/66)

In general, to fix “redundant null check due to previous dereference” you either (a) move the null check to *before* any dereference if you truly need to guard against null, or (b) remove the redundant check if prior logic already guarantees the pointer is non-null. Here, the condition `if (cp && *cp)` on line 1745 both checks `cp` for null and dereferences `*cp`. So inside that block, `cp` cannot be null. That means all the later uses of `cp ? cp : "<NULL>"` inside this block are redundant and can be simplified to just `cp`.

The minimal, behavior‑preserving fix is:

- Keep the outer guard `if (cp && *cp)` exactly as it is, because that is where the null protection and “non-empty string” semantics are implemented.
- Within that `if` block, for each call that currently passes `cp ? cp : "<NULL>"` and `cp ? (int)strlen(cp) : 0`, replace these expressions with `cp` and `(int)strlen(cp)` respectively.
- Do not touch any code outside the shown region, and do not add any imports or new functions; this is a pure in-place simplification.

Concretely, in `src/netmush/command.c`, inside the `while (cmdline && (!qent || qent == mushstate.qfirst) && !mushstate.break_called)` loop, update the three calls between lines 1748–1755 to stop using the ternary null-fallback for `cp` and its length.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
