### PR TITLE
Potential fix for code scanning alert no. 67: Redundant null check due to previous dereference

### DIFF
--- a/src/netmush/command.c
+++ b/src/netmush/command.c
@@ -1747,12 +1747,12 @@ void process_cmdline(dbref player, dbref cause, char *cmdline, char *args[], int
 
 					   notify_check(player, player, MSG_PUP_ALWAYS | MSG_ME_ALL | MSG_F_DOWN, NULL,
 										 "[DEBUG process_cmdline] RAW cp='%s' (len=%d)",
-										 cp ? cp : "<NULL>", cp ? (int)strlen(cp) : 0);
+										 cp, (int)strlen(cp));
 					   log_write(LOG_ALWAYS, "TRIG", "CMDLINE", "[DEBUG process_cmdline] RAW cp='%s' (len=%d) (player=#%d, cause=#%d)",
-								 cp ? cp : "<NULL>", cp ? (int)strlen(cp) : 0, player, cause);
+								 cp, (int)strlen(cp), player, cause);
 					   notify_check(player, player, MSG_PUP_ALWAYS | MSG_ME_ALL | MSG_F_DOWN, NULL,
 									 "[DEBUG process_cmdline] about to call process_command: '%s'",
-									 cp ? cp : "<NULL>");
+									 cp);
 				       numpipes = 0;
 				       while (cmdline && (*cmdline == '|') && (!qent || qent == mushstate.qfirst) && (numpipes < mushconf.ntfy_nest_lim))
 				       {


### PR DESCRIPTION
Potential fix for [https://github.com/TinyMUSH/TinyMUSH/security/code-scanning/67](https://github.com/TinyMUSH/TinyMUSH/security/code-scanning/67)

In general, to fix a “redundant null check due to previous dereference” you either (a) move the null check before the first dereference so it actually guards against null, or (b) remove the later, now-unnecessary null check. Here, the first dereference of `cp` (`*cp`) is already properly guarded by `if (cp && *cp)`, so `cp` is guaranteed to be non-null within that `if` block. Therefore the simplest and safest fix is to remove the redundant `cp ? ... : ...` ternaries in the logging and notification calls and use `cp` directly.

Concretely, within `src/netmush/command.c`, in the shown region around lines 1745–1755, update the three debug lines that currently use `cp ? cp : "<NULL>"` and `cp ? (int)strlen(cp) : 0`. Replace these with direct uses of `cp` and `strlen(cp)`, since `cp` is non-null in that block. No changes are needed to the surrounding logic, no new imports are required, and no behavior will change in reachable code paths: the only difference is that the impossible `<NULL>` formatting branches are removed, making the code more straightforward and satisfying the static analyzer.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
