### PR TITLE
Potential fix for code scanning alert no. 68: Redundant null check due to previous dereference

### DIFF
--- a/src/netmush/funobj.c
+++ b/src/netmush/funobj.c
@@ -4144,10 +4144,7 @@ void transform_say(dbref speaker, char *sname, char *str, int key, char *say_str
 
 	XFREE(result);
 
-	if (trans_str)
-	{
-		XFREE(trans_str);
-	}
+	XFREE(trans_str);
 
 	if (empty_str)
 	{


### PR DESCRIPTION
Potential fix for [https://github.com/TinyMUSH/TinyMUSH/security/code-scanning/68](https://github.com/TinyMUSH/TinyMUSH/security/code-scanning/68)

In general, to fix a “redundant null check due to previous dereference”, either move the null check before the first dereference (if the pointer can legitimately be null) or remove the later redundant check (if the pointer is guaranteed non-null by design). Here, the function already dereferences `trans_str` at line 4017 (`if (trans_str && *trans_str)`), so any null check at line 4147 cannot protect against null dereference. The minimal, behavior-preserving change is to remove the `if (trans_str)` guard and unconditionally call `XFREE(trans_str);`, relying on the existing assumption that `trans_str` is valid when the function is called.

Concretely, in `src/netmush/funobj.c`, in the region around lines 4145–4155, replace the `if (trans_str) { XFREE(trans_str); }` block with a single unconditional `XFREE(trans_str);`. Leave the `empty_str` handling unchanged, since `empty_str` may still legitimately be null and is not dereferenced earlier. No new imports, helper methods, or definitions are required; we only adjust the free logic.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
