### PR TITLE
Potential fix for code scanning alert no. 70: Redundant null check due to previous dereference

### DIFF
--- a/src/netmush/look.c
+++ b/src/netmush/look.c
@@ -2663,7 +2663,7 @@ void sweep_check(dbref player, dbref what, int key, int is_loc)
 				for (s = buff + 1; *s && (*s != ':'); s++)
 					;
 
-				if (s)
+				if (*s == ':')
 				{
 					canhear = 1;
 					break;


### PR DESCRIPTION
Potential fix for [https://github.com/TinyMUSH/TinyMUSH/security/code-scanning/70](https://github.com/TinyMUSH/TinyMUSH/security/code-scanning/70)

In general, to fix a “redundant null check due to previous dereference” you either (a) move the null check before any dereference to make it meaningful, or (b) remove the redundant check if the pointer is guaranteed non-NULL whenever it is used. Here, `s` is initialized from `buff + 1` and only used/indexed inside the `for` condition and increment; `buff` has already been checked for NULL, so `s` cannot be NULL in this block. The code that follows clearly wants to know whether the loop found a colon (`':'`) character, not whether `s` is non-NULL.

The single best way to fix this without changing existing functionality is to replace `if (s)` with a condition that reflects the actual intent: check whether the loop terminated because it found `':'` rather than because it reached the end of the string. The loop stops on either `*s == '\0'` or `*s == ':'`; therefore, if `*s == ':'` after the loop, a colon was found. In practice, the existing `if (s)` will always be true and thus `canhear` is set and the loop broken as long as `buff` is non-empty, which is slightly different behavior. However, given the comment “Make sure there's a : in it”, the intended behavior is almost certainly “set `canhear` only when a ':' is present”, so changing `if (s)` to `if (*s == ':')` both removes the redundant null check and aligns the code with the comment. The edit is confined to the `if (s)` line in src/netmush/look.c around lines 2663–2669, and no new imports or helper methods are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
