### PR TITLE
Potential fix for code scanning alert no. 71: Redundant null check due to previous dereference

### DIFF
--- a/src/netmush/set.c
+++ b/src/netmush/set.c
@@ -1302,7 +1302,7 @@ void do_cpattr(dbref player, dbref cause, int key, char *oldpair, char *newpair[
 	ATTR *oldattr;
 	char *s;
 
-	if (!*oldpair || !**newpair || !oldpair || !*newpair)
+	if (!oldpair || !newpair || !*newpair || !*oldpair || !**newpair)
 	{
 		return;
 	}


### PR DESCRIPTION
Potential fix for [https://github.com/TinyMUSH/TinyMUSH/security/code-scanning/71](https://github.com/TinyMUSH/TinyMUSH/security/code-scanning/71)

In general, to fix a “redundant null check due to previous dereference” you must ensure that any pointer is tested for null before it is dereferenced, or remove the null check entirely if the pointer is guaranteed non-null. Here, we want to keep the existing guard logic but make it safe: check `oldpair` and `newpair` (and `*newpair`) for null before dereferencing them.

The best minimal change is to reorder and slightly restructure the initial `if` in `do_cpattr` so that:
- Pointers are checked for null first.
- Only if they are non-null do we dereference them to test emptiness.

Concretely, in `src/netmush/set.c` within `do_cpattr`, replace:

```c
if (!*oldpair || !**newpair || !oldpair || !*newpair)
{
    return;
}
```

with:

```c
if (!oldpair || !newpair || !*newpair || !*oldpair || !**newpair)
{
    return;
}
```

This preserves the original logical intent (“bail out if any of these are missing/empty”) but evaluates the checks in a safe order. No new imports, methods, or definitions are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
