### PR TITLE
fix(eval.c): fix parsing of %= substitution parameter (again)

### DIFF
--- a/src/netmush/eval.c
+++ b/src/netmush/eval.c
@@ -1080,6 +1080,10 @@ void eval_expression_string(char *buff, char **bufc, dbref player, dbref caller,
 
 				break;
 
+			case '=':
+		        // Equivalent of generic v() attr get
+		        (*dstr)++;
+
 				if (**dstr != '<')
 				{
 					(*dstr)--;


### PR DESCRIPTION
Commit 2ad0b2af59889f08703e3c0b345ea7ab6d645801 mistakenly removes the case statement for parsing %= attribute substitution, which comes right after the heavily refactored ansi color handling.

This commit adds the case statement back, fixing the regression and causing regression suite `eval_substitutions.conf` to pass again.