### PR TITLE
Add GitHub action for automated regression testing

### DIFF
--- a/.github/workflows/macos-latest.yml
+++ b/.github/workflows/macos-latest.yml
@@ -1,4 +1,4 @@
-name: Build Test (MacOS Latest)
+name: Build (MacOS)
 
 on:
   push:

--- a/.github/workflows/ubuntu-latest.yml
+++ b/.github/workflows/ubuntu-latest.yml
@@ -1,4 +1,4 @@
-name: Build Test (Ubuntu Latest)
+name: Build & Test (Ubuntu)
 
 on:
   push:
@@ -11,6 +11,7 @@ permissions:
 
 jobs:
   build:
+    name: Build
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
@@ -41,3 +42,52 @@ jobs:
         ls -la modules/
         
         echo "Integration test completed - binary is functional"
+    - name: upload artifact
+      uses: actions/upload-artifact@v4
+      with:
+        name: netmush
+        path: game/
+        retention-days: 1
+  list-tests:
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
+    steps:
+      - uses: actions/checkout@v2
+      - id: set-matrix
+        run: echo "matrix=$(ls scripts/*.conf | jq -R -s -c 'split("\n")[:-1]')" >> $GITHUB_OUTPUT
+  regression-test:
+    name: Regression
+    needs:
+      - build
+      - list-tests 
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        testfile: ${{ fromJson(needs.list-tests.outputs.matrix) }}
+    env:
+      TINY_PASS: potrzebie
+      TINY_PORT: 6250
+    steps:
+    - uses: actions/checkout@v4
+    - uses: actions/setup-python@v6
+      with:
+        python-version: '3.10'
+        cache: 'pip'
+    - run: pip install telnetlib3
+    - name: download artifact
+      uses: actions/download-artifact@v5
+      with:
+        name: netmush
+        path: game/
+    - name: run test suite
+      env:
+        TINY_CONFIG_FILE: ${{ github.workspace }}/${{ matrix.testfile }}
+      shell: bash
+      run: |
+        cd game
+        chmod +x netmush
+        ./netmush -m
+        $GITHUB_WORKSPACE/scripts/regression_test.py --auto-shutdown
+

--- a/scripts/regression_test.py
+++ b/scripts/regression_test.py
@@ -71,6 +71,7 @@ def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description="TinyMUSH regression test runner")
     parser.add_argument("--config", "-c", default=DEFAULT_CONFIG, help="Path to the test config file")
     parser.add_argument("--allow-disconnect", action="store_true", help="Run commands that may close the session")
+    parser.add_argument("--auto-shutdown", action="store_true", help="Automatically issue a @shutdown command when the test suite concludes")
     parser.add_argument("--delay", "-d", type=float, default=0.2, help="Delay between commands in seconds (default: 0.2)")
     parser.add_argument("--verbose", "-v", action="store_true", help="Show detailed output for debugging")
     return parser.parse_args()
@@ -223,7 +224,10 @@ def main() -> None:
 
     # Graceful logout if possible
     try:
-        tn.write(b"QUIT\n")
+        if args.auto_shutdown:
+            tn.write(b"@shutdown\n")
+        else:
+            tn.write(b"QUIT\n")
     except Exception:
         pass
     tn.close()

--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -1,0 +1,1 @@
+telnetlib3


### PR DESCRIPTION
I figured it might be useful to run the entire suite in an automated fashion. Even now, several regressions have already crept in.

We can adjust the parameters as desired; for example, we could enable the `fail-fast` parameter to prevent further tests from being executed after the first failure. Personally, though, I like having a complete test report.