### PR TITLE
fix(eval.c): Do not swallow opening parenthesis if they are not part of a function call

### DIFF
--- a/scripts/eval_parenthesis.conf
+++ b/scripts/eval_parenthesis.conf
@@ -13,3 +13,13 @@ think (( | ((
 think )) | ))
 
 think [()] | #-1 FUNCTION () NOT FOUND
+
+@desc me=It's the wizard.
+
+think get(me/desc) | It's the wizard.
+
+think [get(me/desc)] | It's the wizard.
+
+think (me/desc) | (me/desc)
+
+think oget(me/desc) | oget(me/desc)

--- a/src/netmush/eval.c
+++ b/src/netmush/eval.c
@@ -1489,6 +1489,11 @@ void eval_expression_string(char *buff, char **bufc, dbref player, dbref caller,
 					*bufc = oldp;
 					XSAFESPRINTF(buff, bufc, "#-1 FUNCTION (%s) NOT FOUND", xtbuf);
 				}
+				else
+				{
+					// Preserve the parenthesis verbatim
+					XSAFELBCHR('(', buff, bufc);
+				}
 
 				eval &= ~EV_FCHECK;
 				break;


### PR DESCRIPTION
when `EV_FCHECK` is on but `EV_FMAND` is off (i.e. we do check for functions, but it's okay if the preceding word is not a valid function name), then if an opening parenthesis is encountered that is not part of a valid function call, that parenthesis is swallowed.

We need to preserve the opening parenthesis if we find no valid function name but `EV_FMAND` is 0. (In that case, the string should be produced verbatim)

Fixes regression test `eval_parenthesis.conf`