### PR TITLE
fix(constants.h): Update `REG_CASELESS` to match `PCRE2_CASELESS` flag.

### DIFF
--- a/src/netmush/constants.h
+++ b/src/netmush/constants.h
@@ -1151,7 +1151,7 @@
  * from perform_grep (grep, grepi, wildgrep, regrep, regrepi):
  *
  */
-#define REG_CASELESS 0x01  /*!< XXX must equal PCRE2_CASELESS */
+#define REG_CASELESS 0x08  /*!< XXX must equal PCRE2_CASELESS */
 #define REG_MATCH_ALL 0x02 /*!< operate on all matches in a list */
 #define REG_TYPE 0x0c      /*!< mask to select grep type bits */
 #define GREP_EXACT 0


### PR DESCRIPTION
Looks like the value of that flag has changed between PCRE versions, causing `
-i` matches to not actually be executed as `-i` matches.

This should really clean up with the regression failures; most are related to regexp matching.