### PR TITLE
test(functions_logic.conf): Fix erroneously declared test cases

### DIFF
--- a/scripts/functions_logic.conf
+++ b/scripts/functions_logic.conf
@@ -16,10 +16,10 @@ think ncomp(3,3) | 0
 think not(0) | 1
 think not(3) | 0
 think not(-1) | 1
-think t(0) | 1
+think t(0) | 0
 think t(foo) | 1
-think notbool(1) |
-think notbool(0) | 0
+think notbool(1) | 0
+think notbool(0) | 1
 
 # and/or/xor families
 think and(1,2,3) | 1
@@ -29,21 +29,21 @@ think xor(1,0) | 1
 think xor(1,0,1) | 0
 think andbool(1,1,1) | 1
 think orbool(0,0,1) | 1
-think xorbool(1,0,1) | 1
+think xorbool(1,0,1) | 0
 
 # cand/cor short-circuit (unevaluated args)
 think [setq(0,0)][cand(0,setq(0,1))] [r(0)] | 0 0
 think [setq(0,0)][cor(1,setq(0,1))] [r(0)] | 1 0
-think [setq(0,0)][candbool(0,setq(0,1))] [r(0)] | 0 1
-think [setq(0,0)][corbool(1,setq(0,1))] [r(0)] |
+think [setq(0,0)][candbool(0,setq(0,1))] [r(0)] | 0 0
+think [setq(0,0)][corbool(1,setq(0,1))] [r(0)] | 1 0
 
 # list logic
 think land(1;1;0,;) | 0
 think land(1;2;3,;) | 1
 think lor(0;0;2,;) | 1
-think landbool(1;yes;0,;) | 1
+think landbool(1;yes;0,;) | 0
 think lorbool(0;no;1,;) | 1
 
 # list boolean conversion helpers
-think ltrue(1;0;foo,;) | 1;1;1
-think lfalse(1;0;foo,;) | 0;0;0
+think ltrue(1;0;foo;#-1,;) | 1;0;1;0
+think lfalse(1;0;foo;#0,;) | 0;1;0;0


### PR DESCRIPTION
I thought this was going to be the most cursed regression ever.

Turns out, it was just a misconfigured test suite. I'm kind of glad it was this easy ;)

I verified all changed tests with TinyMUSH 3.2.