### PR TITLE
fix(command.c): fix stray invalid escape sequence

### DIFF
--- a/src/netmush/command.c
+++ b/src/netmush/command.c
@@ -2850,7 +2850,7 @@ int cf_cmd_alias(int *vp, char *str, long extra, dbref player, char *cmd)
 
 	if (alias[0] == '_' && alias[1] == '_')
 	{
-		cf_log(player, "CNF", "SYNTX", cmd, "Alias %s would cause \@addcommand conflict", alias);
+		cf_log(player, "CNF", "SYNTX", cmd, "Alias %s would cause @addcommand conflict", alias);
 		return -1;
 	}
 


### PR DESCRIPTION
I think this snuck in with the doxygen rework; it's causing a compiler warning.