### PR TITLE
test(ansi.conf): Support testing for ansi escape sequences

### DIFF
--- a/scripts/regression_test.py
+++ b/scripts/regression_test.py
@@ -170,9 +170,10 @@ def main() -> None:
         print("[login]\n" + login_resp.strip())
 
     # Activate ANSI colors for testing
-    ansi_resp = send_cmd(tn, "@set me=ANSI", TIMEOUT, args.delay)
-    if args.verbose:
-        print("[set ANSI]\n" + ansi_resp.strip())
+    for flag in ["ANSI", "!COLOR256", "!COLOR24BIT"]:
+        flag_resp = send_cmd(tn, f"@set me={flag}", TIMEOUT, args.delay)
+        if args.verbose:
+            print(f"[set {flag}]\n" + flag_resp.strip())
 
     commands = []
     skipped_disconnect = []
@@ -214,7 +215,8 @@ def main() -> None:
             if expected_sub == "" and resp.strip() == "":
                 status = "OK"
             else:
-                status = "OK" if expected_sub in resp else "ERR"
+                expected_ansi = expected_sub.replace("¢", "\033")
+                status = "OK" if expected_ansi in resp else "ERR"
         else:
             # Si pas d'expectation, considérer OK tant qu'il y a une réponse (même vide)
             status = "OK"
@@ -243,7 +245,8 @@ def main() -> None:
         for cmd, expected, resp in failures:
             trimmed = resp.strip()
             preview = trimmed.splitlines()[0] if trimmed else "<no output>"
-            expectation = f" (expected contains: '{expected}')" if expected else ""
+            expected_ansi = expected.replace("¢", "\033")
+            expectation = f" (expected contains: '{expected_ansi}')" if expected else ""
             print(f" - {cmd}: {preview}{expectation}")
 
     # Exit with non-zero status if any command failed

--- a/scripts/test_ansi.conf
+++ b/scripts/test_ansi.conf
@@ -12,3 +12,12 @@ think %xrtest! | test!
 # Note: With ANSI colors enabled, this should produce: \x1b[38;2;128;0;0mtest\x1b[0mtest
 # But this test just checks that both text parts are present
 think %xrtest%xntest | test
+
+# basic foreground colors
+think %xxblack%xrred%xggreen%xyyellow%xbblue%xmmagenta%xccyan%xwwhite | ¢[30mblack¢[31mred¢[32mgreen¢[33myellow¢[34mblue¢[35mmagenta¢[36mcyan¢[37mwhite¢[0m
+
+# basic background colors
+think %xXblack%xRred%xGgreen%xYyellow%xBblue%xMmagenta%xCcyan%xWwhite | ¢[40mblack¢[41mred¢[42mgreen¢[43myellow¢[44mblue¢[45mmagenta¢[46mcyan¢[47mwhite¢[0m
+
+# text effects
+think %xfflash%xhhilite%xuunderline%xiinverse%xnnormal | ¢[5mflash¢[1mhilite¢[4munderline¢[7minverse¢[0mnormal


### PR DESCRIPTION
I'm afraid ansi is broken.

When ANSI is set but the new color flags (COLOR128 and COLOR24BIT) are not set, then the short color names (%xr etc) translate to entirely wrong colors and the text effects (%xb etc) don't get rendered at all.

I've enhanced the regression test suite to be able to catch such issues.

The updated test suite passes against TinyMUSH 3.2 but fails against TinyMUSH 4.

Screenshot of test run against TinyMUSH 3.2:
<img width="921" height="611" alt="image" src="https://github.com/user-attachments/assets/95eb74c7-e2c5-4d22-9a67-d043e74a9290" />

Screenshot of test run against TinyMUSH 4 (branch `tests/ansi-support`):
<img width="1265" height="775" alt="image" src="https://github.com/user-attachments/assets/e6c0614e-1a16-42d0-a5f1-2980f33b958b" />
